### PR TITLE
using ISO 8601 dates to reduce ambiguity

### DIFF
--- a/ios-device-example-format.json
+++ b/ios-device-example-format.json
@@ -14,8 +14,8 @@
 		processor_name : "Samsung 1176JZ(F)-S", //i.e.: A8, A8X
 		architecture : "armv6",
 		
-		device_launch_date : "01/07/2007", //date
-		device_discontinued_date : "01/07/2007", //if this object is not present then the decvies is assumed to be sill available
+		device_launch_date : "2007-01-07", // ISO 8601 date
+		device_discontinued_date : "2007-07-01", //if this object is not present then the decvies is assumed to be sill available
 		
 		min_ios_version : 1000, //1.0
 		max_ios_version : 3130, //3.1.3
@@ -23,14 +23,14 @@
 		os_versions : [
 		
 			//v1.0
-			{ version_name : "1.0", 	version : 1000, build : "1A543a", 	baseband : "03.11.02_G", 	release_date : "29/07/2007", support_level : 0 },
-			{ version_name : "1.0.1", 	version : 1010, build : "1C25", 	baseband : "03.12.08_G", 	release_date : "31/08/2007", support_level : 0 },
-			{ version_name : "1.0.2", 	version : 1020, build : "1C28", 	baseband : "03.14.08_G", 	release_date : "21/08/2007", support_level : 0 },
-			{ version_name : "1.1", 	version : 1100, build : "3A101a", 	baseband : "???", 			release_date : "14/09/2007", support_level : 0 },
-			{ version_name : "1.1.1", 	version : 1110, build : "3A109a", 	baseband : "04.01.13_G", 	release_date : "27/09/2007", support_level : 0 },
-			{ version_name : "1.1.2", 	version : 1120, build : "3B48b", 	baseband : "04.02.13_G", 	release_date : "11/11/2007", support_level : 0 },
-			{ version_name : "1.1.3", 	version : 1130, build : "4A93", 	baseband : "04.03.13_G", 	release_date : "15/01/2008", support_level : 0 },
-			{ version_name : "1.1.4", 	version : 1140, build : "4A102", 	baseband : "04.04.05_G", 	release_date : "26/02/2008", support_level : 0 },
+			{ version_name : "1.0", 	version : 1000, build : "1A543a", 	baseband : "03.11.02_G", 	release_date : "2007-01-07", support_level : 0 },
+			{ version_name : "1.0.1", 	version : 1010, build : "1C25", 	baseband : "03.12.08_G", 	release_date : "2007-08-31", support_level : 0 },
+			{ version_name : "1.0.2", 	version : 1020, build : "1C28", 	baseband : "03.14.08_G", 	release_date : "2007-08-21", support_level : 0 },
+			{ version_name : "1.1", 	version : 1100, build : "3A101a", 	baseband : "???", 			release_date : "2007-09-14", support_level : 0 },
+			{ version_name : "1.1.1", 	version : 1110, build : "3A109a", 	baseband : "04.01.13_G", 	release_date : "2007-09-27", support_level : 0 },
+			{ version_name : "1.1.2", 	version : 1120, build : "3B48b", 	baseband : "04.02.13_G", 	release_date : "2007-11-11", support_level : 0 },
+			{ version_name : "1.1.3", 	version : 1130, build : "4A93", 	baseband : "04.03.13_G", 	release_date : "2008-01-15", support_level : 0 },
+			{ version_name : "1.1.4", 	version : 1140, build : "4A102", 	baseband : "04.04.05_G", 	release_date : "2008-02-26", support_level : 0 },
 			
 			//v2.0
 			
@@ -55,5 +55,5 @@
 
 		notes : "extra info",
 		
-		last_updated : "19/10/2014 23:45:00"
+		last_updated : "2014-10-19T23:45:00+00:00"
 	}


### PR DESCRIPTION
It's mostly because of the 'last modified' field and potential issues with users in different time zones.
